### PR TITLE
fix(memory/sync): send fetch_type in Notion NOTION_FETCH_DATA args

### DIFF
--- a/src/memory/sync/composio/providers/notion.rs
+++ b/src/memory/sync/composio/providers/notion.rs
@@ -71,7 +71,7 @@ impl IncrementalSource for NotionSyncPipeline {
         _: &SyncState,
         page: Option<&str>,
     ) -> Value {
-        let mut args = serde_json::json!({"page_size": self.page_size, "filter": {"value": "page", "property": "object"}, "sort": {"direction": "descending", "timestamp": "last_edited_time"}});
+        let mut args = serde_json::json!({"fetch_type": "pages", "page_size": self.page_size, "filter": {"value": "page", "property": "object"}, "sort": {"direction": "descending", "timestamp": "last_edited_time"}});
         if let Some(page) = page {
             args["start_cursor"] = serde_json::json!(page);
         }

--- a/tests/composio_sync_mock.rs
+++ b/tests/composio_sync_mock.rs
@@ -491,6 +491,9 @@ async fn todoist_reingests_edited_task_without_timestamp_change() {
 async fn notion_fetches_markdown_and_counts_both_requests() {
     let server = MockServer::start().await;
     Mock::given(path("/tools/execute/NOTION_FETCH_DATA"))
+        .and(body_partial_json(
+            serde_json::json!({"arguments": {"fetch_type": "pages"}}),
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"successful": true, "data": {"results": [{"id": "page-1", "title": "Roadmap", "last_edited_time": "2026-03-01T00:00:00Z"}]}})))
         .mount(&server).await;
     Mock::given(path("/tools/execute/NOTION_GET_PAGE_MARKDOWN"))


### PR DESCRIPTION
## Summary

Composio's `NOTION_FETCH_DATA` action now requires a `fetch_type` field. The memory-sync Notion provider's `arguments()` never sent it, so every periodic Notion memory sync failed with `Following fields are missing: {'fetch_type'}`.

This adds `"fetch_type": "pages"` to the sync provider's request args. It's unconditional because this path hardcodes `filter: {value: "page"}`, so `"pages"` is the only valid value (the agent-tool path's inference logic is deliberately not duplicated here).

The agent-tool path in OpenHuman already handles this via `ensure_notion_fetch_type`; only this memory-sync path was still missing the field.

Fixes tinyhumansai/openhuman#5506.

## API Or Behavior Changes

None — internal request-args shape only. Adds a field the upstream Composio API now requires.

## Tests

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1396 tests, 0 failed

Added a `body_partial_json` matcher on the `NOTION_FETCH_DATA` mock in `tests/composio_sync_mock.rs` asserting the outgoing request carries `fetch_type: "pages"` (fails pre-fix), following the existing Slack/ClickUp request-body matcher pattern in the same file.

## Documentation

None needed — internal provider request shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Notion page synchronization by explicitly requesting page data during fetches.
  * Preserved existing pagination, filtering, and sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->