### PR TITLE
docs(pii): land the #154 post-approval polish that missed the squash

### DIFF
--- a/src/memory/store/safety/pii.rs
+++ b/src/memory/store/safety/pii.rs
@@ -122,11 +122,14 @@ static CC_RE: LazyLock<Regex> =
 //   `panNumber` all lowercase into these.
 // * Native-script terms, per this module's multilingual mandate (the Aadhaar
 //   and My Number patterns already carry theirs). CJK terms match as
-//   substrings — CJK text does not put `[\W_]` between a word and the
-//   digits that follow it.
+//   substrings because CJK sentences provide no `[\W_]` boundaries around a
+//   word — the case this buys is a keyword embedded mid-sentence
+//   (`…信用卡账单 <PAN>`). It does not buy `卡号<PAN>` with the digits
+//   directly attached: there `CC_RE`'s own leading `\b` already fails
+//   (CJK is `\w`), so the run is never a candidate in the first place.
 static CC_KEYWORD_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?i)(?:^|[\W_])(?:card|credit|debit|visa|mastercard|amex|american\s?express|discover|jcb|diners|unionpay|maestro|hipercard|elo|rupay|cvv|cvc|cc|pan|tarjeta|cart[aã]o|carte|karte|карта|карты|карту|картой|карте|кредитка)(?:[\W_]|$)|(?i:cardnumber|creditcard|ccnum|cardno|pannumber|カード|信用卡|卡号|银行卡|카드)",
+        r"(?i)(?:^|[\W_])(?:card|credit|debit|visa|mastercard|amex|american\s?express|discover|jcb|diners|unionpay|hipercard|rupay|cvv|cvc|cc|pan|tarjeta|cart[aã]o|carte|karte|карта|карты|карту|картой|карте|кредитка)(?:[\W_]|$)|(?i:cardnumber|creditcard|ccnum|cardno|pannumber|カード|信用卡|卡号|银行卡|카드)",
     )
     .expect("cc keyword")
 });


### PR DESCRIPTION
## Summary

#154's squash was cut at `ef1eb19`; the post-approval commit `bfd2ea2` — addressing @oxoxDev's approval notes — was pushed but never made it into the merge. This re-lands it on main, byte-identical (verified: zero content diff vs `bfd2ea2`).

Two changes:
- **CJK-tier doc corrected** to the case the substring tier actually covers (keyword embedded mid-sentence, `…信用卡账单 <PAN>`) — and why digit-attached `卡号<PAN>` was never a candidate at all (`CC_RE`'s leading `\b` fails on CJK-`\w`).
- **Bare `elo` and `maestro` dropped** from the standalone keyword list — both networks are covered structurally by the IIN table, and as English words they were the loosest entries.

Docs + one regex literal; no behavior change beyond the two keywords narrowing. Safety suite 82 passed, fmt clean.

Follow-up once this merges: an openhuman `vendor/tinycortex` re-pin from the now-orphaned `bfd2ea2` (a PR-head SHA openhuman main currently points at, reachable only via `refs/pull/154/head`) to the resulting main SHA — restoring the fresh-clone reachability guarantee and closing the content drift between openhuman's pin and tinycortex main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit-card number detection to reduce false-positive redactions caused by standalone “maestro” or “elo” keywords.
  * Existing multilingual and boundary-based matching behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->