### PR TITLE
fix(ci): skip crates.io package/publish while the crate is unpublishable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,31 @@ jobs:
           git commit -m "Release ${RELEASE_TAG}"
           git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
 
+      # `$CRATE_NAME` (and its path dependency `tinycortex-api`) both carry
+      # `publish = false` right now: `tinycortex-api` depends on `tinymemory-api`
+      # by git rev, and cargo refuses to package/publish a crate whose
+      # dependency graph contains an unpublished git/path dependency (see the
+      # `publish = false` comments in Cargo.toml and api/Cargo.toml, tracked as
+      # tinymemory#18 §A1). Packaging or publishing while that holds always
+      # fails, so skip both steps until the crate is actually publishable
+      # instead of hard-failing the whole release (which also blocks the
+      # version-bump tag from ever being pushed).
+      - name: Check crates.io publishability
+        id: publishable
+        run: |
+          set -euo pipefail
+
+          publish="$(cargo metadata --no-deps --format-version 1 | jq -r --arg crate "$CRATE_NAME" '.packages[] | select(.name == $crate) | .publish')"
+          if [[ "$publish" == "[]" ]]; then
+            echo "publishable=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${CRATE_NAME} has publish = false; skipping crates.io package/publish steps."
+          else
+            echo "publishable=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Package crate
-        run: cargo package --locked
+        if: steps.publishable.outputs.publishable == 'true'
+        run: cargo package --locked -p "$CRATE_NAME"
 
       - name: Push release commit and tag
         env:
@@ -129,6 +152,7 @@ jobs:
           git push origin "${RELEASE_TAG}"
 
       - name: Publish to crates.io
-        run: cargo publish --locked
+        if: steps.publishable.outputs.publishable == 'true'
+        run: cargo publish --locked -p "$CRATE_NAME"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

Release run [33327821333](https://github.com/tinyhumansai/tinycortex/actions/runs/33327821333) (`gh workflow run release.yml --ref main -f bump=patch`) failed in the **Package crate** step:

```
error: failed to verify manifest at `/home/runner/work/tinycortex/tinycortex/api/Cargo.toml`

Caused by:
  all dependencies must have a version requirement specified when packaging.
  dependency `tinymemory-api` does not specify a version
```

### Root cause

- `cargo package --locked` (no `-p`) packages **every** workspace default-member — `[".", "api"]` per `Cargo.toml` — so it also tries to package `api/`. `api/Cargo.toml`'s `tinymemory-api` dependency is a bare `git` reference with no `version` key, and cargo refuses to package anything whose dependency graph contains an unpublished git/path dependency without a version requirement.
- Scoping to `-p tinycortex` alone doesn't fix it either — I reproduced that locally too (`cargo package -p tinycortex --locked` → `no matching package named 'tinycortex-api' found`). Both `tinycortex` and `tinycortex-api` already carry `publish = false` in their `Cargo.toml`s, exactly because this same git dependency (`tinymemory-api`, tracked as tinymemory#18 §A1) makes crates.io publishing genuinely impossible right now — this is documented, pre-existing, and deliberate, not a regression. This was simply the first release run ever triggered against this workflow, so it had never been exercised end-to-end.
- This differs from the sibling `tinyagents` release failure (which failed earlier, in "Compute next version", because a workspace-inherited version wasn't literally greppable). Here "Compute next version" succeeds fine — `cargo metadata` resolves `tinycortex`'s version correctly. The failure is entirely about `cargo package`/`cargo publish` being run against a crate graph that isn't publishable yet.

### Fix

`.github/workflows/release.yml`: add a **Check crates.io publishability** step that reads the resolved `publish` field for `$CRATE_NAME` via `cargo metadata --no-deps --format-version 1 | jq`, and gate the **Package crate** / **Publish to crates.io** steps on it being publishable (`publish` is `null`, not `[]`). While it's `publish = false`, those two steps are skipped (with a `::notice::`) instead of hard-failing the whole release — which also means the version-bump commit and git tag still get pushed, since "Push release commit and tag" runs unconditionally. Also scoped both `cargo package`/`cargo publish` invocations to `-p "$CRATE_NAME"` so `api/` (never meant to be published by this workflow) isn't swept in once packaging does become possible.

### Verification

Ran locally in the checkout:
- `cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="tinycortex") | .publish'` → `[]`, matching the new skip condition.
- `cargo package -p tinycortex-api --locked` and `cargo package -p tinycortex --locked` both reproduce the exact CI failure locally (manifest verification error / unresolvable `tinycortex-api` on crates.io respectively), confirming root cause.
- `cargo package --list -p tinycortex --locked` succeeds and lists only the root crate's files.
- Did not run the test suite per task scope (build/tests already pass on `main`; this is a workflow-only fix).

## Test plan

- [ ] Re-run `gh workflow run release.yml --ref main -f bump=patch` after merge and confirm the release job completes: version bump, tag, and push succeed, and "Package crate"/"Publish to crates.io" are skipped with the new notice (until `tinymemory#18 §A1` makes the crate genuinely publishable).