### PR TITLE
fix(ci): force-push the throwaway release branch so retries aren't blocked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,10 @@ jobs:
           git checkout -b "${release_branch}"
           git add Cargo.toml Cargo.lock
           git commit -m "Release ${RELEASE_TAG}"
-          git push origin "${release_branch}"
+          # A previous failed run can leave this throwaway branch behind, which
+          # would make the retry's push a non-fast-forward. The branch only ever
+          # holds the version bump for this exact tag, so overwriting it is safe.
+          git push --force origin "${release_branch}"
 
           echo "branch=${release_branch}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

Release run [33329333792](https://github.com/tinyhumansai/tinycortex/actions/runs/33329333792) failed in **Commit version bump**:

```
 ! [rejected]        release/v0.1.2 -> release/v0.1.2 (non-fast-forward)
error: failed to push some refs to 'https://github.com/tinyhumansai/tinycortex'
```

An earlier failed run (33329114653) had already created and pushed `release/v0.1.2` before dying at the merge step. The retry recomputes the same version, builds the same branch name from a fresh commit, and its push is therefore a non-fast-forward against the leftover branch. Every retry at the same version hits this — the workflow is blocked by its own debris.

## Fix

Force-push the throwaway release branch. It only ever carries the version bump for that exact tag and is deleted by `gh pr merge --delete-branch` on success, so overwriting a leftover copy is safe.

I also deleted the stranded `release/v0.1.2` branch so the next run starts clean.

## Verification

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses cleanly. CI configuration only; no code changes, so no tests were run.

Follow-up to #160 and #161.